### PR TITLE
Fix misinformative error in generator

### DIFF
--- a/gen/terraform/tags.go
+++ b/gen/terraform/tags.go
@@ -34,7 +34,7 @@ func GenerateResourceTypesWithTagsList(resourceTypes []string, outputPath string
 
 	provider, ok := providers[awsClientKey]
 	if !ok {
-		return nil, fmt.Errorf("Terraform AWS provider not found: %s", err)
+		return nil, fmt.Errorf("Terraform AWS provider not found")
 	}
 
 	defer func() {


### PR DESCRIPTION
## Summary
- improve `Terraform AWS provider not found` error message by removing nil interpolation

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840a0d17218833291590766d8c87380